### PR TITLE
Use -nv for wget

### DIFF
--- a/map-creator
+++ b/map-creator
@@ -43,10 +43,10 @@ mkdir -p "$POIS_PATH"
 
 # Download
 
-wget -N -P "$DATA_PATH" http://download.geofabrik.de/$1-latest.osm.pbf
-wget -N -P "$DATA_PATH" http://download.geofabrik.de/$1-latest.osm.pbf.md5
+wget -N -P -nv "$DATA_PATH" http://download.geofabrik.de/$1-latest.osm.pbf
+wget -N -P -nv "$DATA_PATH" http://download.geofabrik.de/$1-latest.osm.pbf.md5
 (cd "$DATA_PATH" && exec md5sum -c "$NAME-latest.osm.pbf.md5") || exit
-wget -N -P "$DATA_PATH" http://download.geofabrik.de/$1.poly
+wget -N -P -nv "$DATA_PATH" http://download.geofabrik.de/$1.poly
 
 # Bounds
 


### PR DESCRIPTION
The -nv flag for wget reduced the output of wget. If you want to log the output of the script, you end up with something like this:
```
Saving to: ‘/var/www/mapsforge/data/europe/germany/berlin/berlin-latest.osm.pbf’

     0K .......... .......... .......... .......... ..........  0% 3,43M 15s
    50K .......... .......... .......... .......... ..........  0% 9,61M 10s
   100K .......... .......... .......... .......... ..........  0% 12,1M 8s
   150K .......... .......... .......... .......... ..........  0% 5,80M 8s
   200K .......... .......... .......... .......... ..........  0% 10,7M 8s
   250K .......... .......... .......... .......... ..........  0% 5,45M 8s
   300K .......... .......... .......... .......... ..........  0% 5,67M 8s
   350K .......... .......... .......... .......... ..........  0% 11,0M 8s
   400K .......... .......... .......... .......... ..........  0% 5,71M 8s
   450K .......... .......... .......... .......... ..........  0% 5,11M 8s
   500K .......... .......... .......... .......... ..........  1% 10,5M 8s
   550K .......... .......... .......... .......... ..........  1% 10,8M 8s
   600K .......... .......... .......... .......... ..........  1% 12,3M 7s
   650K .......... .......... .......... .......... ..........  1% 6,49M 7s
   700K .......... .......... .......... .......... ..........  1% 18,4M 7s
   750K .......... .......... .......... .......... ..........  1% 16,7M 7s
   800K .......... .......... .......... .......... ..........  1%  138M 6s
   850K .......... .......... .......... .......... ..........  1% 5,73M 7s
   900K .......... .......... .......... .......... ..........  1% 9,53M 6s
   950K .......... .......... .......... .......... ..........  1% 17,8M 6s
  1000K .......... .......... .......... .......... ..........  1%  120M 6s
  1050K .......... .......... .......... .......... ..........  2% 12,4M 6s
......
```