### PR TITLE
Make paths configurable

### DIFF
--- a/map-creator
+++ b/map-creator
@@ -113,6 +113,7 @@ CMD="$OSMOSIS_HOME/bin/osmosis --rb file=$DATA_PATH/merge.pbf \
 if [ "$TAG_CONF_FILE" != "" ]; then
  CMD="$CMD tag-conf-file=$TAG_CONF_FILE"
 fi
+echo "Calling $CMD"
 $CMD
 
 # POI
@@ -122,4 +123,5 @@ CMD="$OSMOSIS_HOME/bin/osmosis" --rb file="$DATA_PATH/$NAME-latest.osm.pbf" \
 if [ "$TAG_CONF_FILE" != "" ]; then
  CMD="$CMD tag-conf-file=$TAG_CONF_FILE"
 fi 
+echo "Calling $CMD"
 $CMD

--- a/map-creator
+++ b/map-creator
@@ -102,30 +102,28 @@ sed -i "s/\$RIGHT/$RIGHT/g" "$DATA_PATH/sea.osm"
                             --wb file="$DATA_PATH/merge.pbf" omitmetadata=true
 
 # Map
-
-CMD="$OSMOSIS_HOME/bin/osmosis --rb file=$DATA_PATH/merge.pbf \
+if [ "$SKIP_MAP_CREATION" != "true" ]; then
+  CMD="$OSMOSIS_HOME/bin/osmosis --rb file=$DATA_PATH/merge.pbf \
                                --mw file=$MAPS_PATH/$NAME.map \
                                     type=$2 \
                                     bbox=$BOTTOM,$LEFT,$TOP,$RIGHT \
                                     map-start-position=$LAT,$LON \
                                     map-start-zoom=8"
-[ $3 ] && CMD="$CMD preferred-languages=$3"
-if [ "$MAP_TAG_CONF_FILE" != "" ]; then
- CMD="$CMD tag-conf-file=$MAP_TAG_CONF_FILE"
+  [ $3 ] && CMD="$CMD preferred-languages=$3"
+  if [ "$MAP_TAG_CONF_FILE" != "" ]; then
+   CMD="$CMD tag-conf-file=$MAP_TAG_CONF_FILE"
+  fi
+  echo "Calling $CMD"
+  $CMD
 fi
-echo "Calling $CMD"
-$CMD
-
-if [ "$SKIP_POI_CREATION" = "true" ]; then
- exit
-fi 
 
 # POI
-
-CMD="$OSMOSIS_HOME/bin/osmosis --rb file=$DATA_PATH/$NAME-latest.osm.pbf \
+if [ "$SKIP_POI_CREATION" != "true" ]; then
+  CMD="$OSMOSIS_HOME/bin/osmosis --rb file=$DATA_PATH/$NAME-latest.osm.pbf \
                             --pw file=$POIS_PATH/$NAME.poi"
-if [ "$POI_TAG_CONF_FILE" != "" ]; then
- CMD="$CMD tag-conf-file=$POI_TAG_CONF_FILE"
+  if [ "$POI_TAG_CONF_FILE" != "" ]; then
+    CMD="$CMD tag-conf-file=$POI_TAG_CONF_FILE"
+  fi 
+  echo "Calling $CMD"
+  $CMD 
 fi 
-echo "Calling $CMD"
-$CMD

--- a/map-creator
+++ b/map-creator
@@ -110,18 +110,22 @@ CMD="$OSMOSIS_HOME/bin/osmosis --rb file=$DATA_PATH/merge.pbf \
                                     map-start-position=$LAT,$LON \
                                     map-start-zoom=8"
 [ $3 ] && CMD="$CMD preferred-languages=$3"
-if [ "$TAG_CONF_FILE" != "" ]; then
- CMD="$CMD tag-conf-file=$TAG_CONF_FILE"
+if [ "$MAP_TAG_CONF_FILE" != "" ]; then
+ CMD="$CMD tag-conf-file=$MAP_TAG_CONF_FILE"
 fi
 echo "Calling $CMD"
 $CMD
 
+if [ "$SKIP_POI_CREATION" = "true" ]; then
+ exit
+fi 
+
 # POI
 
-CMD="$OSMOSIS_HOME/bin/osmosis" --rb file="$DATA_PATH/$NAME-latest.osm.pbf" \
-                            --pw file="$POIS_PATH/$NAME.poi"
-if [ "$TAG_CONF_FILE" != "" ]; then
- CMD="$CMD tag-conf-file=$TAG_CONF_FILE"
+CMD="$OSMOSIS_HOME/bin/osmosis --rb file=$DATA_PATH/$NAME-latest.osm.pbf \
+                            --pw file=$POIS_PATH/$NAME.poi"
+if [ "$POI_TAG_CONF_FILE" != "" ]; then
+ CMD="$CMD tag-conf-file=$POI_TAG_CONF_FILE"
 fi 
 echo "Calling $CMD"
 $CMD

--- a/map-creator
+++ b/map-creator
@@ -110,9 +110,16 @@ CMD="$OSMOSIS_HOME/bin/osmosis --rb file=$DATA_PATH/merge.pbf \
                                     map-start-position=$LAT,$LON \
                                     map-start-zoom=8"
 [ $3 ] && CMD="$CMD preferred-languages=$3"
+if [ "$TAG_CONF_FILE" != "" ]; then
+ CMD="$CMD tag-conf-file=$TAG_CONF_FILE"
+fi
 $CMD
 
 # POI
 
-"$OSMOSIS_HOME/bin/osmosis" --rb file="$DATA_PATH/$NAME-latest.osm.pbf" \
+CMD="$OSMOSIS_HOME/bin/osmosis" --rb file="$DATA_PATH/$NAME-latest.osm.pbf" \
                             --pw file="$POIS_PATH/$NAME.poi"
+if [ "$TAG_CONF_FILE" != "" ]; then
+ CMD="$CMD tag-conf-file=$TAG_CONF_FILE"
+fi 
+$CMD

--- a/map-creator
+++ b/map-creator
@@ -1,5 +1,6 @@
 #!/bin/bash
 # Copyright (C) 2017 devemux86
+# Copyright (C) 2017 boldtrn
 #
 # Mapsforge map creation (with coastlines)
 # with OpenStreetMap data from Geofabrik
@@ -7,14 +8,30 @@
 # Configuration
 
 # http://wiki.openstreetmap.org/wiki/Osmosis
-OSMOSIS_HOME="$HOME/programs/osmosis"
+
+OSMOSIS_HOME=$OSMOSIS_HOME_CONFIG
+if [ "$OSMOSIS_HOME_CONFIG" = "" ]; then
+ OSMOSIS_HOME="$HOME/programs/osmosis"
+fi
 
 # http://data.openstreetmapdata.com/land-polygons-split-4326.zip
-LAND_PATH="$HOME/mapsforge/land-polygons-split-4326"
+LAND_PATH=$LAND_PATH_CONFIG
+if [ "$LAND_PATH_CONFIG" = "" ]; then
+ LAND_PATH="$HOME/mapsforge/land-polygons-split-4326"
+fi
 
-DATA_PATH="$HOME/mapsforge/data"
-MAPS_PATH="$HOME/mapsforge/maps"
-POIS_PATH="$HOME/mapsforge/pois"
+DATA_PATH=$DATA_PATH_CONFIG
+if [ "$DATA_PATH_CONFIG" = "" ]; then
+ DATA_PATH="$HOME/mapsforge/data"
+fi
+MAPS_PATH=$MAPS_PATH_CONFIG
+if [ "$MAPS_PATH_CONFIG" = "" ]; then
+ MAPS_PATH="$HOME/mapsforge/maps"
+fi
+POIS_PATH=$POIS_PATH_CONFIG
+if [ "$POIS_PATH_CONFIG" = "" ]; then
+ POIS_PATH="$HOME/mapsforge/pois"
+fi
 
 # =========== DO NOT CHANGE AFTER THIS LINE. ===========================
 # Below here is regular code, part of the file. This is not designed to


### PR DESCRIPTION
Make it easy to configure the paths.

So now you can change the OSMOSIS_HOME path by running: `export OSMOSIS_HOME_CONFIG="/opt/osmosis/"`.

I was so free to add my name in the header :). We can remove this, this is not really necessary for me :).