### PR TITLE
Fail fast if there is an issue during the download

### DIFF
--- a/map-creator
+++ b/map-creator
@@ -69,10 +69,10 @@ fi
 
 # Download
 
-wget -nv -N -P "$DATA_PATH" http://download.geofabrik.de/$1-latest.osm.pbf
-wget -nv -N -P "$DATA_PATH" http://download.geofabrik.de/$1-latest.osm.pbf.md5
+wget -nv -N -P "$DATA_PATH" http://download.geofabrik.de/$1-latest.osm.pbf || exit 1
+wget -nv -N -P "$DATA_PATH" http://download.geofabrik.de/$1-latest.osm.pbf.md5 || exit 1
 (cd "$DATA_PATH" && exec md5sum -c "$NAME-latest.osm.pbf.md5") || exit 1
-wget -nv -N -P "$DATA_PATH" http://download.geofabrik.de/$1.poly
+wget -nv -N -P "$DATA_PATH" http://download.geofabrik.de/$1.poly || exit 1
 
 # Bounds
 


### PR DESCRIPTION
If there is an issue during the download, we don't exit, this PR adds this behavior.

From `man wget`:
```
       Wget may return one of several error codes if it encounters problems.

       0   No problems occurred.

       1   Generic error code.

       2   Parse error---for instance, when parsing command-line options, the .wgetrc or .netrc...

       3   File I/O error.

       4   Network failure.

       5   SSL verification failure.

       6   Username/password authentication failure.

       7   Protocol errors.

       8   Server issued an error response.

       With the exceptions of 0 and 1, the lower-numbered exit codes take precedence over higher-numbered ones, when multiple types of errors are encountered.
```